### PR TITLE
Add Plug context

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # react-plugin
 
-[![ci status](https://github.com/skidding/react-plugin/actions/workflows/test.yml/badge.svg)](https://github.com/skidding/react-plugin/actions/workflows/test.yml)
-[![coverage status](https://codecov.io/gh/skidding/react-plugin/graph/badge.svg?token=AT1EQ7J3WX)](https://codecov.io/gh/skidding/react-plugin)
+[![ci status](https://github.com/ovidiuch/react-plugin/actions/workflows/test.yml/badge.svg)](https://github.com/ovidiuch/react-plugin/actions/workflows/test.yml)
+[![coverage status](https://codecov.io/gh/ovidiuch/react-plugin/graph/badge.svg?token=AT1EQ7J3WX)](https://codecov.io/gh/ovidiuch/react-plugin)
 
 API for composable 3rd party React plugins

--- a/src/PlugConnect.tsx
+++ b/src/PlugConnect.tsx
@@ -1,11 +1,13 @@
-import {
+import React, {
   createElement,
   ReactNode,
   useCallback,
   useEffect,
+  useMemo,
   useState,
 } from 'react';
 import { getPluginContext, getPlugins, onStateChange } from 'ui-plugin';
+import { PlugContext } from './PlugContext';
 import { PlugComponentType } from './types';
 
 type Props = {
@@ -39,7 +41,16 @@ export function PlugConnect({
     return onStateChange(updatePlugProps);
   }, [updatePlugProps]);
 
-  return createElement(component, plugProps, children);
+  const contextValue = useMemo(
+    () => ({ pluginContext: getPluginContext(pluginName), slotProps }),
+    [pluginName, slotProps],
+  );
+
+  return (
+    <PlugContext.Provider value={contextValue}>
+      {createElement(component, plugProps, children)}
+    </PlugContext.Provider>
+  );
 }
 
 function getPlugProps(pluginName: string, slotProps: object) {

--- a/src/PlugContext.tsx
+++ b/src/PlugContext.tsx
@@ -2,14 +2,19 @@ import { createContext, useContext } from 'react';
 import { PluginSpec } from 'ui-plugin';
 import { PlugContextValue } from './types';
 
-export const PlugContext =
-  createContext<PlugContextValue<PluginSpec, {}>>(null);
+export const PlugContext = createContext<PlugContextValue<
+  PluginSpec,
+  {}
+> | null>(null);
 
 export function usePlugContext<
   TSpec extends PluginSpec,
-  TSlotProps extends {},
+  TSlotProps extends {} = {},
 >() {
-  const value = useContext(PlugContext);
+  const value = useContext(PlugContext) as PlugContextValue<
+    TSpec,
+    TSlotProps
+  > | null;
   if (!value) throw new Error('Plug context missing');
-  return value as PlugContextValue<TSpec, TSlotProps>;
+  return value;
 }

--- a/src/PlugContext.tsx
+++ b/src/PlugContext.tsx
@@ -1,0 +1,15 @@
+import { createContext, useContext } from 'react';
+import { PluginSpec } from 'ui-plugin';
+import { PlugContextValue } from './types';
+
+export const PlugContext =
+  createContext<PlugContextValue<PluginSpec, {}>>(null);
+
+export function usePlugContext<
+  TSpec extends PluginSpec,
+  TSlotProps extends {},
+>() {
+  const value = useContext(PlugContext);
+  if (!value) throw new Error('Plug context missing');
+  return value as PlugContextValue<TSpec, TSlotProps>;
+}

--- a/src/__tests__/slot.tsx
+++ b/src/__tests__/slot.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { act, ReactTestRenderer } from 'react-test-renderer';
 import { loadPlugins, PluginContext } from 'ui-plugin';
 import { createPlugin } from '../createPlugin';
+import { usePlugContext } from '../PlugContext';
 import { resetPlugins } from '../pluginStore';
 import { Slot } from '../Slot';
 import { createRenderer } from '../testHelpers/createRenderer';
@@ -84,6 +85,38 @@ it('passes down slot props', () => {
   plug<{ age: number }>('root', ({ slotProps }) => (
     <AgeComponent age={slotProps.age} />
   ));
+  register();
+
+  loadPlugins();
+  const renderer = createRenderer(<Slot name="root" slotProps={{ age: 29 }} />);
+  expect(renderer.toJSON()).toMatchInlineSnapshot(`"29y old"`);
+});
+
+it('passes down pluginContext via plug context', () => {
+  const { plug, register } = createPlugin<Test>({
+    name: 'test',
+    initialState: { age: 29 },
+  });
+  plug('root', () => {
+    const { pluginContext } = usePlugContext<Test>();
+    return <AgeComponent age={pluginContext.getState().age} />;
+  });
+  register();
+
+  loadPlugins();
+  const renderer = createRenderer(<Slot name="root" />);
+  expect(renderer.toJSON()).toMatchInlineSnapshot(`"29y old"`);
+});
+
+it('passes down slot props via plug context', () => {
+  const { plug, register } = createPlugin<Test>({
+    name: 'test',
+    initialState: { age: 28 },
+  });
+  plug<{ age: number }>('root', () => {
+    const { slotProps } = usePlugContext<Test, { age: number }>();
+    return <AgeComponent age={slotProps.age} />;
+  });
   register();
 
   loadPlugins();

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ export {
 } from 'ui-plugin';
 export { ArraySlot } from './ArraySlot';
 export { createPlugin } from './createPlugin';
+export { usePlugContext } from './PlugContext';
 export { PluginsConsumer } from './PluginsConsumer';
 export { resetPlugins } from './pluginStore';
 export { Slot } from './Slot';

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,6 +7,14 @@ export type PlugProps<TSpec extends PluginSpec, TSlotProps extends {}> = {
   slotProps: TSlotProps;
 };
 
+export type PlugContextValue<
+  TSpec extends PluginSpec,
+  TSlotProps extends {},
+> = {
+  pluginContext: PluginContext<TSpec>;
+  slotProps: TSlotProps;
+} | null;
+
 export type PlugComponentType<
   TSpec extends PluginSpec,
   TSlotProps extends {},

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,7 +13,7 @@ export type PlugContextValue<
 > = {
   pluginContext: PluginContext<TSpec>;
   slotProps: TSlotProps;
-} | null;
+};
 
 export type PlugComponentType<
   TSpec extends PluginSpec,


### PR DESCRIPTION
While convenient, this implementation of `usePlugContext` is fundamentally broken because it isn't reactive. Plugs can indirectly read state from other plugins through non-reactive getters. This is fine at the moment because all Plugs re-render on any plugin state change. In the future this can be optimized by creating a graph of plugin dependancies based on cross-plugin method calls.

When we access the plugin context via `usePlugContext` inside the render tree of a Plug, we also access plugin state indirectly via non-reactive getters, and in this case we could have a parent `React.memo` boundary that prevents the component where `usePlugContext` is used from re-rendering on plugin state changes. To fix this we can add a global plugin state listener wherever we use `usePlugContext`, like we do at the root of every Plug, but this sounds like a performance red flag at scale.

Unless we implement some sort of plugin dependency graph like mentioned above to be able to choose which Plugs should re-render based on which plugin state changes, this idea will be put on hold in favor of each plugin creating their own context to pass values derived from other plugins' state down the render tree.